### PR TITLE
feat: toggle Khmer search feature via ENABLE_KHMER_SEARCH env var

### DIFF
--- a/database/migrations/20250401083736_create_normalize_khmer_search_function.js
+++ b/database/migrations/20250401083736_create_normalize_khmer_search_function.js
@@ -5,6 +5,8 @@
  * by removing zero-width space characters (U+200B)
  */
 async function up(knex) {
+  if (process.env.ENABLE_KHMER_SEARCH !== 'true') return;
+
   // Create the normalize_khmer_search function
   return knex.raw(`
     CREATE OR REPLACE FUNCTION normalize_khmer_search(input_text TEXT) 

--- a/database/migrations/20260227000000_add_khmer_search_trgm_indexes.js
+++ b/database/migrations/20260227000000_add_khmer_search_trgm_indexes.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * This migration enables the pg_trgm extension and creates GIN indexes
+ * on the normalized Khmer text columns for faster ILIKE searches.
+ *
+ * If pg_trgm is not available on the host (e.g. Railway), the migration
+ * logs a warning and completes successfully without creating indexes.
+ */
+async function up(knex) {
+  if (process.env.ENABLE_KHMER_SEARCH !== 'true') return;
+
+  try {
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS pg_trgm;');
+  } catch (err) {
+    console.warn(
+      '[migration] pg_trgm extension is not available on this database. ' +
+      'Khmer search will still work but without trigram indexes. ' +
+      'Error:', err.message
+    );
+    return;
+  }
+
+  try {
+    await knex.raw(`
+      CREATE INDEX IF NOT EXISTS idx_resources_khmer_title_trgm
+      ON resources USING GIN (normalize_khmer_search(khmer_title) gin_trgm_ops);
+    `);
+
+    await knex.raw(`
+      CREATE INDEX IF NOT EXISTS idx_resources_khmer_description_trgm
+      ON resources USING GIN (normalize_khmer_search(khmer_description) gin_trgm_ops);
+    `);
+  } catch (err) {
+    console.warn(
+      '[migration] Failed to create trigram indexes. ' +
+      'Khmer search will still work but without index optimization. ' +
+      'Error:', err.message
+    );
+  }
+}
+
+async function down(knex) {
+  await knex.raw('DROP INDEX IF EXISTS idx_resources_khmer_description_trgm;');
+  await knex.raw('DROP INDEX IF EXISTS idx_resources_khmer_title_trgm;');
+}
+
+module.exports = { up, down };

--- a/database/migrations/20260228000000_fix_khmer_function_immutable_and_add_indexes.js
+++ b/database/migrations/20260228000000_fix_khmer_function_immutable_and_add_indexes.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * Re-creates normalize_khmer_search() as IMMUTABLE so it can be used
+ * in index expressions, then attempts to create pg_trgm GIN indexes.
+ * Index creation fails gracefully if pg_trgm is not available.
+ */
+async function up(knex) {
+  if (process.env.ENABLE_KHMER_SEARCH !== 'true') return;
+
+  // Re-create the function with IMMUTABLE volatility
+  await knex.raw(`
+    CREATE OR REPLACE FUNCTION normalize_khmer_search(input_text TEXT)
+    RETURNS TEXT AS $$
+    BEGIN
+      IF input_text IS NULL THEN
+        RETURN NULL;
+      END IF;
+      RETURN REPLACE(input_text, U&'\\200B', '');
+    END;
+    $$ LANGUAGE plpgsql IMMUTABLE;
+  `);
+
+  // Attempt to create trigram indexes — fails gracefully if pg_trgm is unavailable
+  try {
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS pg_trgm;');
+
+    await knex.raw(`
+      CREATE INDEX IF NOT EXISTS idx_resources_khmer_title_trgm
+      ON resources USING GIN (normalize_khmer_search(khmer_title) gin_trgm_ops);
+    `);
+
+    await knex.raw(`
+      CREATE INDEX IF NOT EXISTS idx_resources_khmer_description_trgm
+      ON resources USING GIN (normalize_khmer_search(khmer_description) gin_trgm_ops);
+    `);
+  } catch (err) {
+    console.warn(
+      '[migration] Could not create trigram indexes. ' +
+      'Khmer search will still work but without index optimization. ' +
+      'Error:', err.message
+    );
+  }
+}
+
+async function down(knex) {
+  await knex.raw('DROP INDEX IF EXISTS idx_resources_khmer_description_trgm;');
+  await knex.raw('DROP INDEX IF EXISTS idx_resources_khmer_title_trgm;');
+
+  await knex.raw(`
+    CREATE OR REPLACE FUNCTION normalize_khmer_search(input_text TEXT)
+    RETURNS TEXT AS $$
+    BEGIN
+      IF input_text IS NULL THEN
+        RETURN NULL;
+      END IF;
+      RETURN REPLACE(input_text, U&'\\200B', '');
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+}
+
+module.exports = { up, down };

--- a/src/api/resource/controllers/custom-search.js
+++ b/src/api/resource/controllers/custom-search.js
@@ -3,30 +3,22 @@
 module.exports = {
   async khmerSearch(ctx) {
     try {
-      // Get search query from URL parameters
       const { search } = ctx.query;
-      
+
       if (!search) {
         return { data: [], meta: { pagination: { page: 1, pageSize: 25, pageCount: 0, total: 0 } } };
       }
 
-      console.log('Searching for Khmer text:', search);
-      
-      // Get database connection
       const knex = strapi.db.connection;
-      
-      // Use the collectionName from your schema
       const tableName = 'resources';
-      
-      // Get pagination params (same as Strapi's default)
+
       const page = parseInt(ctx.query.page) || 1;
       const pageSize = parseInt(ctx.query.pageSize) || 25;
       const start = (page - 1) * pageSize;
-      
-      // First attempt: remove zero-width spaces for entire phrase search
+
+      // Remove zero-width spaces for phrase search
       const searchNoZWS = search.replace(/\u200B/g, '');
-      console.log('Search term without zero-width spaces:', searchNoZWS);
-      
+
       const phraseSqlQuery = `
         SELECT id, document_id FROM "${tableName}"
         WHERE (
@@ -36,22 +28,18 @@ module.exports = {
         AND published_at IS NOT NULL
         LIMIT ? OFFSET ?
       `;
-      
-      // Execute the phrase search
+
       const phraseResults = await knex.raw(
         phraseSqlQuery,
         [`%${searchNoZWS}%`, `%${searchNoZWS}%`, pageSize, start]
       );
-      
+
       let documentIds = phraseResults.rows.map(row => row.document_id);
       let total = 0;
-      
+
       if (documentIds.length > 0) {
-        console.log('Found results using phrase search:', documentIds.length);
-        
-        // Get total count for phrase search
         const countResult = await knex.raw(
-          `SELECT COUNT(*) FROM "${tableName}" 
+          `SELECT COUNT(*) FROM "${tableName}"
            WHERE (
              normalize_khmer_search(khmer_title) ILIKE normalize_khmer_search(?)
              OR normalize_khmer_search(khmer_description) ILIKE normalize_khmer_search(?)
@@ -61,113 +49,89 @@ module.exports = {
         );
         total = parseInt(countResult.rows[0].count);
       } else {
-        // Second attempt: treat zero-width spaces as word separators and search for each word using LIKE
-        console.log('No results with phrase search, trying word-by-word search treating zero-width spaces as separators');
-        
-        // Split the original search term by both regular spaces and zero-width spaces
+        // Treat zero-width spaces as word separators and search for each word
         const searchTerms = search.split(/[\s\u200B]+/).filter(term => term.length > 0);
-        console.log('Search terms after splitting:', searchTerms);
-        
+
         if (searchTerms.length > 0) {
-          // Build query conditions for each term using ? placeholders.
-          // Each term must appear in either the title or description (AND logic across terms)
           let queryConditions = searchTerms.map(() => {
             return `(normalize_khmer_search(khmer_title) ILIKE normalize_khmer_search(?)
                     OR normalize_khmer_search(khmer_description) ILIKE normalize_khmer_search(?))`;
           }).join(' AND ');
-          
-          // Create parameters array: one pair per term, wrapped in %
+
           let searchParams = [];
           searchTerms.forEach(term => {
             searchParams.push(`%${term}%`);
             searchParams.push(`%${term}%`);
           });
-          
-          // Append pagination parameters
+
           searchParams.push(pageSize);
           searchParams.push(start);
-          
-          // Build SQL query using ? placeholders
+
           const wordSqlQuery = `
             SELECT id, document_id FROM "${tableName}"
             WHERE ${queryConditions}
             AND published_at IS NOT NULL
             LIMIT ? OFFSET ?
           `;
-          
-          console.log('Word-by-word SQL Query:', wordSqlQuery);
-          console.log('SQL Params:', searchParams);
-          
+
           const wordResults = await knex.raw(wordSqlQuery, searchParams);
           documentIds = wordResults.rows.map(row => row.document_id);
-          
+
           if (documentIds.length > 0) {
-            // Remove pagination parameters for count query
             let countParams = searchParams.slice(0, -2);
             const countQuery = `
-              SELECT COUNT(*) FROM "${tableName}" 
+              SELECT COUNT(*) FROM "${tableName}"
               WHERE ${queryConditions}
               AND published_at IS NOT NULL
             `;
-            
+
             const countResult = await knex.raw(countQuery, countParams);
             total = parseInt(countResult.rows[0].count);
           }
         }
       }
-      
-      // Third attempt: if no results found by previous methods, try auto-segmentation as a last resort
+
+      // Third attempt: auto-segmentation using Intl.Segmenter for Khmer
       if (documentIds.length === 0) {
-        console.log('No results found with phrase or word-by-word search. Trying auto-segmentation as a last resort.');
-        
-        // Attempt to auto-segment the search input using Intl.Segmenter (if supported)
         let segmentedTerms = [];
         try {
           const segmenter = new Intl.Segmenter('km', { granularity: 'word' });
           segmentedTerms = Array.from(segmenter.segment(search))
             .map(segment => segment.segment)
             .filter(Boolean);
-          console.log('Auto-segmented terms:', segmentedTerms);
         } catch (err) {
-          console.error('Intl.Segmenter is not available or failed. Consider a fallback segmentation library.', err);
+          strapi.log.error('Intl.Segmenter failed for Khmer segmentation', err);
         }
-        
+
         if (segmentedTerms.length > 0) {
-          // Build query conditions for each segmented term
           let queryConditions = segmentedTerms.map(() => {
             return `(normalize_khmer_search(khmer_title) ILIKE normalize_khmer_search(?)
                     OR normalize_khmer_search(khmer_description) ILIKE normalize_khmer_search(?))`;
           }).join(' AND ');
-          
-          // Create parameters array: one pair per segmented term, wrapped in %
+
           let searchParams = [];
           segmentedTerms.forEach(term => {
             searchParams.push(`%${term}%`);
             searchParams.push(`%${term}%`);
           });
-          
-          // Append pagination parameters
+
           searchParams.push(pageSize);
           searchParams.push(start);
-          
-          // Build the SQL query using the segmented tokens
+
           const segmentedSqlQuery = `
             SELECT id, document_id FROM "${tableName}"
             WHERE ${queryConditions}
             AND published_at IS NOT NULL
             LIMIT ? OFFSET ?
           `;
-          console.log('Segmented SQL Query:', segmentedSqlQuery);
-          console.log('SQL Params:', searchParams);
-          
+
           const segmentedResults = await knex.raw(segmentedSqlQuery, searchParams);
           documentIds = segmentedResults.rows.map(row => row.document_id);
-          
+
           if (documentIds.length > 0) {
-            // Remove pagination parameters for count query
             let countParams = searchParams.slice(0, -2);
             const countQuery = `
-              SELECT COUNT(*) FROM "${tableName}" 
+              SELECT COUNT(*) FROM "${tableName}"
               WHERE ${queryConditions}
               AND published_at IS NOT NULL
             `;
@@ -176,8 +140,7 @@ module.exports = {
           }
         }
       }
-      
-      // If no results from any search approach, return empty data
+
       if (documentIds.length === 0) {
         return {
           data: [],
@@ -191,20 +154,25 @@ module.exports = {
           }
         };
       }
-      
-      // Use Strapi's entity service with documentId to get the complete data
-      const fullResults = await strapi.entityService.findMany('api::resource.resource', {
+
+      // Use Strapi's Document Service API to get complete data
+      const fullResults = await strapi.documents('api::resource.resource').findMany({
         filters: {
           documentId: {
             $in: documentIds
           }
         },
-        publicationState: 'published', // Explicitly request published items
-        populate: '*'  // Populate all relationships
+        status: 'published',
+        populate: {
+          FeaturedImage: true,
+          eBook: true,
+          authors: { fields: ['Name', 'slug'] },
+          categories: { fields: ['EnglishName', 'KhmerName', 'slug'] },
+          publishers: { fields: ['EnglishName', 'KhmerName', 'slug'] },
+          type: { fields: ['EnglishName', 'KhmerName', 'slug'] },
+        },
       });
-      
-      console.log('Fetched full resources:', fullResults.length);
-      
+
       // Helper function to sanitize user objects
       const sanitizeUser = (user) => {
         if (!user) return null;
@@ -214,8 +182,8 @@ module.exports = {
           lastname: user.lastname
         };
       };
-      
-      // Helper function to recursively sanitize all data
+
+      // Recursively sanitize sensitive fields from response data
       const sanitizeData = (data) => {
         if (!data) return null;
         if (Array.isArray(data)) {
@@ -237,8 +205,8 @@ module.exports = {
         }
         return data;
       };
-      
-      // Sanitize and order the results to match the original documentIds order
+
+      // Sanitize and preserve the original order from the SQL query
       const sanitizedResults = sanitizeData(fullResults);
       const orderedResults = [];
       for (const docId of documentIds) {
@@ -247,7 +215,7 @@ module.exports = {
           orderedResults.push(matchingResource);
         }
       }
-      
+
       return {
         data: orderedResults,
         meta: {
@@ -260,7 +228,7 @@ module.exports = {
         }
       };
     } catch (error) {
-      console.error('Khmer search error:', error);
+      strapi.log.error('Khmer search error:', error);
       ctx.throw(500, 'Error performing Khmer search');
     }
   }

--- a/src/api/resource/routes/custom-routes.js
+++ b/src/api/resource/routes/custom-routes.js
@@ -1,5 +1,5 @@
-module.exports = {
-    routes: [
+const routes = process.env.ENABLE_KHMER_SEARCH === 'true'
+  ? [
       {
         method: 'GET',
         path: '/resources/khmer-search',
@@ -9,5 +9,7 @@ module.exports = {
           policies: [],
         },
       },
-    ],
-  };
+    ]
+  : [];
+
+module.exports = { routes };


### PR DESCRIPTION
Guard all Khmer search functionality behind ENABLE_KHMER_SEARCH=true so apps without Khmer content skip migrations, DB functions, and route registration entirely. Also upgrades custom-search controller to use Document Service API, scoped populate, and strapi.log.